### PR TITLE
fix index page and add missing modules

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,11 +4,12 @@
     <meta charset="UTF-8">
     <title>2D Shooter</title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
+    <link rel="icon" href="assets/favicon.ico">
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
     <div id="ui-overlay"></div>
     <canvas id="gameCanvas" width="1200" height="800"></canvas>
-    <script type="module" src="js/game.js"></script>
+    <script type="module" src="./js/game.js"></script>
 </body>
 </html>

--- a/js/bullet.js
+++ b/js/bullet.js
@@ -1,0 +1,27 @@
+export class BulletManager {
+    constructor(assets, canvas, ctx) {
+        this.assets = assets;
+        this.canvas = canvas;
+        this.ctx = ctx;
+        this.bullets = [];
+    }
+    shoot(x, y) {
+        this.bullets.push({ x, y, speed: 500 });
+    }
+    update(dt, enemies, effects) {
+        this.bullets = this.bullets.filter(b => {
+            b.y -= b.speed * dt;
+            return b.y > -10;
+        });
+    }
+    render(ctx) {
+        for (const b of this.bullets) {
+            if (this.assets.bullet) {
+                ctx.drawImage(this.assets.bullet, b.x - 4, b.y - 8);
+            } else {
+                ctx.fillStyle = '#ff0';
+                ctx.fillRect(b.x - 2, b.y - 8, 4, 8);
+            }
+        }
+    }
+}

--- a/js/effects.js
+++ b/js/effects.js
@@ -1,0 +1,5 @@
+export class Effects {
+    constructor(assets, canvas, ctx) {}
+    update(dt) {}
+    render(ctx) {}
+}

--- a/js/enemy.js
+++ b/js/enemy.js
@@ -1,0 +1,33 @@
+export class EnemyManager {
+    constructor(assets, canvas, ctx) {
+        this.assets = assets;
+        this.canvas = canvas;
+        this.ctx = ctx;
+        this.enemies = [];
+    }
+    spawnWave(wave) {
+        for (let i = 0; i < wave; i++) {
+            this.enemies.push({ x: 50 + i * 60, y: 40, speed: 50 });
+        }
+    }
+    update(dt, player, bullets, effects, wave) {
+        for (const e of this.enemies) {
+            e.y += e.speed * dt;
+        }
+        // Remove enemies off screen
+        this.enemies = this.enemies.filter(e => e.y < this.canvas.height + 40);
+    }
+    render(ctx) {
+        for (const e of this.enemies) {
+            if (this.assets.enemy) {
+                ctx.drawImage(this.assets.enemy, e.x - 20, e.y - 20);
+            } else {
+                ctx.fillStyle = '#f00';
+                ctx.fillRect(e.x - 20, e.y - 20, 40, 40);
+            }
+        }
+    }
+    cleared() {
+        return this.enemies.length === 0;
+    }
+}

--- a/js/game.js
+++ b/js/game.js
@@ -236,16 +236,8 @@ function gameLoop(now) {
 }
 
 // Render function, parallax backgrounds, only redraw as needed
-function renderBackground() {
-    // Parallax backgrounds
-    ctx.clearRect(0, 0, canvas.width, canvas.height);
-    if (assets.background2) ctx.drawImage(assets.background2, 0, 0, canvas.width, canvas.height);
-    if (assets.background) ctx.drawImage(assets.background, 0, 0, canvas.width, canvas.height);
-  renderBackground();
-}
-
 function render() {
-    
+
     // Game objects
     powerups.render(ctx);
     player.render(ctx);

--- a/js/hud.js
+++ b/js/hud.js
@@ -1,0 +1,19 @@
+export class HUD {
+    constructor(canvas, player, score, wave) {
+        this.canvas = canvas;
+        this.player = player;
+        this.score = score;
+        this.wave = wave;
+        this.el = document.createElement('div');
+        this.el.className = 'hud';
+        document.body.appendChild(this.el);
+    }
+    update(player, score, wave) {
+        this.player = player;
+        this.score = score;
+        this.wave = wave;
+    }
+    render() {
+        this.el.textContent = `Health: ${this.player.health} Score: ${this.score} Wave: ${this.wave}`;
+    }
+}

--- a/js/powerup.js
+++ b/js/powerup.js
@@ -1,0 +1,14 @@
+export class PowerupManager {
+    constructor(assets, canvas, ctx) {
+        this.assets = assets;
+        this.canvas = canvas;
+        this.ctx = ctx;
+        this.powerups = [];
+    }
+    update(dt, player, effects) {
+        // no-op placeholder
+    }
+    render(ctx) {
+        // no-op placeholder
+    }
+}

--- a/js/utils.js
+++ b/js/utils.js
@@ -1,0 +1,17 @@
+export async function loadAssets() {
+    const sources = {
+        player: 'assets/player.png',
+        enemy: 'assets/enemy.png',
+        bullet: 'assets/bullet.png',
+    };
+    const assets = { sfx: {} };
+    await Promise.all(Object.entries(sources).map(([key, src]) => {
+        return new Promise(resolve => {
+            const img = new Image();
+            img.src = src;
+            img.onload = resolve;
+            assets[key] = img;
+        });
+    }));
+    return assets;
+}


### PR DESCRIPTION
## Summary
- include favicon and correct module path in index
- implement minimal enemy, bullet, powerup, hud, effects and asset loader modules
- remove unused recursive background renderer

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c75c7a18e483218315eaab6c9418d2